### PR TITLE
Recommendation modifications

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -220,7 +220,7 @@
         <version>2.19.1</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <skipTests>true</skipTests>
+          <!-- <skipTests>true</skipTests> -->
         </configuration>
       </plugin>
 

--- a/portfolio/src/main/java/com/google/sps/agents/Memory.java
+++ b/portfolio/src/main/java/com/google/sps/agents/Memory.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
  */
 public class Memory implements Agent {
 
+  private static Logger log = LoggerFactory.getLogger(Name.class);
+
   private final String intentName;
   private String userID;
   private String fulfillment;
@@ -39,7 +41,6 @@ public class Memory implements Agent {
   private UserService userService;
   private String listName;
   private ArrayList<String> items = new ArrayList<>();
-  private static Logger log = LoggerFactory.getLogger(Memory.class);
 
   /**
    * Memory agent constructor that uses intent and parameter to determnine fulfillment for user
@@ -175,15 +176,17 @@ public class Memory implements Agent {
    * @param parameters Map containing the detected entities in the user's intent.
    */
   private void makeList(Map<String, Value> parameters) throws EntityNotFoundException {
+    MemoryUtils.allocateList(listName, userID, datastore, items);
+    fulfillment = "Created!";
     if (items.isEmpty()) {
-      fulfillment = MemoryUtils.makePastRecommendations(userID, datastore, listName);
-      MemoryUtils.allocateList(listName, userID, datastore, items);
-      MemoryUtils.saveAggregateListData(datastore, userID, listName, items, true);
+      try {
+          fulfillment += MemoryUtils.makePastRecommendations(userID, datastore, listName);
+      } catch (EntityNotFoundException | IllegalStateException e) {
+          log.error("User recommendation error", e);
+          fulfillment += " What are some items to add to your new " + listName + " list?";
+      }
       return;
     }
-    MemoryUtils.allocateList(listName, userID, datastore, items);
-    MemoryUtils.saveAggregateListData(datastore, userID, listName, items, true);
-    fulfillment = "Created!";
     makeMoreRecommendations();
   }
 

--- a/portfolio/src/main/java/com/google/sps/data/Recommender.java
+++ b/portfolio/src/main/java/com/google/sps/data/Recommender.java
@@ -98,6 +98,7 @@ public class Recommender {
    */
   SimpleMatrix matrixFactorization(
       SimpleMatrix dataMatrix, SimpleMatrix userFeatures, SimpleMatrix itemFeatures) {
+    log.info("Input matrix: " + dataMatrix);
     for (int step = 0; step < STEPS; step++) {
       double updated_learning_rate = Math.max(ALPHA_START / (Math.sqrt(step + 1)), 0.005);
       for (int row = 0; row < dataMatrix.numRows(); row++) {
@@ -150,6 +151,7 @@ public class Recommender {
         return estimatedData;
       }
     }
+    log.info("Return matrix: " + userFeatures.mult(itemFeatures));
     return userFeatures.mult(itemFeatures);
   }
 

--- a/portfolio/src/test/java/com/google/sps/MemoryRecommendationsTest.java
+++ b/portfolio/src/test/java/com/google/sps/MemoryRecommendationsTest.java
@@ -94,7 +94,7 @@ public class MemoryRecommendationsTest {
     tester.checkFracAggregate(
         "groceri",
         Arrays.asList("apples", "bananas", "ice cream", "pineapple"),
-        Arrays.asList(1.5, 0.5, 0.5, 1.0));
+        Arrays.asList(1.6, 0.6, 0.6, 1.0));
 
     // 4) updates that list
 
@@ -118,7 +118,7 @@ public class MemoryRecommendationsTest {
     tester.checkFracAggregate(
         "groceri",
         Arrays.asList("apples", "bananas", "ice cream", "pineapple", "chocolate"),
-        Arrays.asList(1.5, 0.5, 1.0, 1.0, 0.5));
+        Arrays.asList(1.6, 0.6, 1.0, 1.0, 0.4));
 
     // 5) creates a list for user 2
 
@@ -184,11 +184,11 @@ public class MemoryRecommendationsTest {
     tester.checkFracAggregate(
         "groceri",
         Arrays.asList("apples", "bananas", "ice cream", "pineapple", "chocolate"),
-        Arrays.asList(4.0 / 3, 1.0 / 3, 1.0, 2.0 / 3, 1.0 / 3));
+        Arrays.asList(1.36, 0.36, 1.0, 0.6, 0.24));
 
     // 9) Create a 4th empty grocery list for user 1 and check past recommendations
     tester.setParameters(
-        "Start a grocery list.",
+        "Start a grocery list 4.",
         "{\"list-name\":\"grocery\", "
             + "\"list-objects\":\"\","
             + "\"new-list\": \"\","
@@ -208,37 +208,27 @@ public class MemoryRecommendationsTest {
     tester.checkFracAggregate(
         "groceri",
         Arrays.asList("apples", "bananas", "ice cream", "pineapple", "chocolate"),
-        Arrays.asList(1.0, 1.0 / 4, 3.0 / 4, 0.5, 1.0 / 4));
+        Arrays.asList(1.36, 0.36, 1.0, 0.6, 0.24));
 
-    // 10) Create a 5th empty grocery list for user 1 and check past recommendations (should now
+    // 10) Create a 5th grocery list for user 1 and check past recommendations (should now
     // only have 2 recommendations)
     tester.setParameters(
-        "Start a grocery list.",
+        "Update a grocery list with apple.",
         "{\"list-name\":\"grocery\", "
-            + "\"list-objects\":\"\","
+            + "\"list-objects\":\"apple\","
             + "\"new-list\": \"\","
             + "\"generic-list\": \"\"}",
-        "memory.list - make");
+        "memory.list - add");
 
     output = tester.getOutput();
     assertEquals(
-        "Created! Based on your previous lists, would you like to add apple and ice cream?",
+        "Updated!",
         output.getFulfillmentText());
-
-    tester.checkDatabaseItems(5, "grocery", new ArrayList<String>());
-    tester.checkAggregate(
-        "groceri",
-        Arrays.asList("apples", "bananas", "ice cream", "pineapple", "chocolate"),
-        Arrays.asList(4, 1, 3, 2, 1));
-    tester.checkFracAggregate(
-        "groceri",
-        Arrays.asList("apples", "bananas", "ice cream", "pineapple", "chocolate"),
-        Arrays.asList(0.8, 0.2, 0.6, 0.4, 0.2));
 
     // 10) Create a 6th and 7th empty grocery list for user 1 and check past recommendations (last
     // one should now only have 1 recommendation)
     tester.setParameters(
-        "Start a grocery list.",
+        "Start a grocery list 6.",
         "{\"list-name\":\"grocery\", "
             + "\"list-objects\":\"\","
             + "\"new-list\": \"\","
@@ -251,7 +241,20 @@ public class MemoryRecommendationsTest {
         output.getFulfillmentText());
 
     tester.setParameters(
-        "Start a grocery list.",
+        "Add apple to my grocery list.",
+        "{\"list-name\":\"grocery\", "
+            + "\"list-objects\":\"apple\","
+            + "\"new-list\": \"\","
+            + "\"generic-list\": \"\"}",
+        "memory.list - add");
+
+    output = tester.getOutput();
+    assertEquals(
+        "Updated!",
+        output.getFulfillmentText());
+
+    tester.setParameters(
+        "Start a grocery list 6.",
         "{\"list-name\":\"grocery\", "
             + "\"list-objects\":\"\","
             + "\"new-list\": \"\","
@@ -279,7 +282,7 @@ public class MemoryRecommendationsTest {
         (List<Pair<String, Integer>>)
             Arrays.asList(
                 new Pair<String, Integer>("apple", 4),
-                new Pair<String, Integer>("banana", 3),
+                new Pair<String, Integer>("banana", 2),
                 new Pair<String, Integer>("carrot", 0),
                 new Pair<String, Integer>("donut", 1)));
     tester.makeUserList(
@@ -321,21 +324,22 @@ public class MemoryRecommendationsTest {
 
     tester.setUser("test@example.com", "1");
     tester.setParameters(
-        "Update grocery list with apple.",
+        "Update grocery list with apple and banana.",
         "{\"list-name\":\"grocery\", "
-            + "\"list-objects\":\"apple\","
+            + "\"list-objects\":\"apple and banana\","
             + "\"new-list\": \"\","
             + "\"generic-list\": \"\"}",
         "memory.list - add");
+    log.info("Testing User 1's recommendations. Should be nothing");
     Output output = tester.getOutput();
     assertEquals(
-        "Updated! Based on your list item history, you might be interested in adding banana to your grocery list.",
+        "Updated!",
         output.getFulfillmentText());
   }
 
   /**
    * Tests recommendations against other users: 1) create 5 users, 2) make new user 2's list, and 3)
-   * assert that no recommendations are returned for user 2.
+   * assert that correct recommendation of banana is returned for user 2.
    */
   @Test
   public void testUser2Recommendations() throws Exception {
@@ -344,10 +348,10 @@ public class MemoryRecommendationsTest {
     // Creates User 1 with history: 1 for item 1, 0.6 for item 2, and 0.2 for item 4.
     tester.makeUserList(
         "1",
-        5,
+        4,
         (List<Pair<String, Integer>>)
             Arrays.asList(
-                new Pair<String, Integer>("apple", 5),
+                new Pair<String, Integer>("apple", 4),
                 new Pair<String, Integer>("banana", 3),
                 new Pair<String, Integer>("carrot", 0),
                 new Pair<String, Integer>("donut", 1)));
@@ -396,13 +400,14 @@ public class MemoryRecommendationsTest {
             + "\"new-list\": \"\","
             + "\"generic-list\": \"\"}",
         "memory.list - make");
+    log.info("Testing User 2's recommendations. Should be banana");
     Output output = tester.getOutput();
-    assertEquals("Created!", output.getFulfillmentText());
+    assertEquals("Created! Based on your list item history, you might be interested in adding banana to your grocery list.", output.getFulfillmentText());
   }
 
   /**
    * Tests recommendations against other users: 1) create 5 users, 2) make a new list, and 3) assert
-   * that 2 correct recommendations are being returned for user 4.
+   * that correct recommendation for carrot and donut is returned for user 4.
    */
   @Test
   public void testUser4Recommendations() throws Exception {
@@ -441,7 +446,7 @@ public class MemoryRecommendationsTest {
         4,
         (List<Pair<String, Integer>>)
             Arrays.asList(
-                new Pair<String, Integer>("apple", 0),
+                new Pair<String, Integer>("apple", 1),
                 new Pair<String, Integer>("banana", 0),
                 new Pair<String, Integer>("carrot", 0),
                 new Pair<String, Integer>("donut", 4)));
@@ -457,13 +462,14 @@ public class MemoryRecommendationsTest {
 
     tester.setUser("test@example.com", "4");
     tester.setParameters(
-        "Make a new grocery list with apple.",
+        "Make a new grocery list with egg.",
         "{\"list-name\":\"grocery\", "
-            + "\"list-objects\":\"apple\","
+            + "\"list-objects\":\"egg\","
             + "\"new-list\": \"\","
             + "\"generic-list\": \"\"}",
         "memory.list - make");
     Output output = tester.getOutput();
+    log.info("Testing User 4's recommendations. Should be carrot and donut??.");
     assertEquals(
         "Created! Based on your list item history, you might be interested in adding carrot and donut to your grocery list.",
         output.getFulfillmentText());

--- a/portfolio/src/test/java/com/google/sps/RecommenderTest.java
+++ b/portfolio/src/test/java/com/google/sps/RecommenderTest.java
@@ -104,12 +104,12 @@ public final class RecommenderTest {
                 new Pair<String, Integer>("banana", 1),
                 new Pair<String, Integer>("carrot", 5),
                 new Pair<String, Integer>("donut", 4)));
-
-    tester.checkFracAggregate("groceri", "1", items, Arrays.asList(1.0, 0.6, 0.0, 0.2));
-    tester.checkFracAggregate("groceri", "2", items, Arrays.asList(0.8, 0.0, 0.0, 0.2));
-    tester.checkFracAggregate("groceri", "3", items, Arrays.asList(0.2, 0.2, 0.0, 1.0));
-    tester.checkFracAggregate("groceri", "4", items, Arrays.asList(0.2, 0.0, 0.0, 0.8));
-    tester.checkFracAggregate("groceri", "5", items, Arrays.asList(0.0, 0.2, 1.0, 0.8));
+    log.info("printing");
+    tester.checkFracAggregate("groceri", "1", items, Arrays.asList(1.0, Math.pow(0.6, 2), 0.0, Math.pow(0.6, 4)));
+    tester.checkFracAggregate("groceri", "2", items, Arrays.asList(1.0, 0.0, 0.0, Math.pow(0.6, 3)));
+    tester.checkFracAggregate("groceri", "3", items, Arrays.asList(Math.pow(0.6, 4), Math.pow(0.6, 4), 0.0, 1.0));
+    tester.checkFracAggregate("groceri", "4", items, Arrays.asList(Math.pow(0.6, 3), 0.0, 0.0, 1.0));
+    tester.checkFracAggregate("groceri", "5", items, Arrays.asList(0.0, Math.pow(0.6, 4), 1.0, 0.6));
 
     List<Entity> entities = tester.fetchDatastoreAllUsers("Frac-groceri");
     Recommender rec = new Recommender();
@@ -118,7 +118,12 @@ public final class RecommenderTest {
             entities.remove(0), entities, new HashSet<String>(StemUtils.stemmedList(items)));
     for (int i = 0; i < 5; i++) {
       for (int j = 0; j < 4; j++) {
-        assertEquals(dataMatrix.get(i, j) / 5, matrix.get(i, j), 0.01);
+        if (dataMatrix.get(i, j) < 1) {
+            assertEquals(0.0, matrix.get(i, j), 0.01);
+        } else {
+            int maxPower = i % 2 == 1 ? 4 : 5;
+            assertEquals(Math.pow(0.6, maxPower - dataMatrix.get(i, j)), matrix.get(i, j), 0.01);
+        }
       }
     }
   }

--- a/portfolio/src/test/java/com/google/sps/TestHelper.java
+++ b/portfolio/src/test/java/com/google/sps/TestHelper.java
@@ -494,7 +494,6 @@ public class TestHelper {
   public void makeUserList(
        String userID, int size, List<Pair<String, Integer>> items)
       throws InvalidProtocolBufferException, IOException {
-    setUser("test@example.com", userID);
     for (int i = 0; i < size; i++) {
       List<Pair<String, Integer>> itemsList = new ArrayList<>((List<Pair<String, Integer>>) items);
       final int temp = i;
@@ -503,17 +502,29 @@ public class TestHelper {
       List<String> filteredStrings =
           filteredPairs.stream().map(e -> e.getKey()).collect(Collectors.toList());
       String stringItems = String.join(", ", filteredStrings);
+      createSingleGroceryList(userID, "make", stringItems);
+      getOutput();
+    }
+  }
+
+/**
+  * Runs one command for making a single grocery list
+  *
+  * @param userID Current user's ID
+  * @param listAction Either "make" or "add" depending on the command user wants to make
+  * @param items List of pairs of strings containing the name of all items expected and integer containing the number of times added to past grocery lists.
+  */
+  public void createSingleGroceryList(String userID, String listAction, String items) throws InvalidProtocolBufferException {
+      setUser("test@example.com", userID);
       setParameters(
-          "Start a grocery list.",
+          listAction + " a grocery list with " + items,
           "{\"list-name\":\"grocery\", "
               + "\"list-objects\":\""
-              + stringItems
+              + items
               + "\","
               + "\"new-list\": \"\","
               + "\"generic-list\": \"\"}",
-          "memory.list - make");
-      getOutput();
-    }
+          "memory.list - " + listAction);
   }
 
   private class TestableTextInputServlet extends TextInputServlet {


### PR DESCRIPTION
Changed how the recommendation system assigns point values for items:

First time a new list type is created / updating a new list type:
- Count (of lists) = 1
- For each item added to first list, item has point value of 1

Creating a new list (with items):
- Count of lists increments by 1
- All existing items point values are halved
- For new items, increment item's point value by 0.6
- Under this structure, items added every time still have a point value of 1. Items added in recent lists have a significantly higher point value (0.6 + 0.4 * previous point value) and items that were added in lists a while ago but not in the recent lists have a much lower point value (pow(0.4, # weeks not added))

Updating a general list (not the first of its type):
- Count of lists is unchanged because updating
- If adding items to a stored empty list, decrease all item point values by a factor of 0.4 (because they weren't decreased on list creation).
- For each item added, increment item value by 0.6

Creating a new list without items:
-  Count of lists increments by 1
- Existing items not multiplied by factor of 0.4 because empty list shouldn't affect point values negatively. For initially empty lists, decrease occurs when lists are updated with values (see above).

Previous point value assignment didn't work well because it was number of times item appeared on lists / total number of lists. So, theoretically, if somebody had no idea what chocolate was for the first n lists and then suddenly starts getting chocolate every week, the point value of chocolate would be really low because it was weighed down by the n initial lists that didn't have it. In this new model, items that are added to the current list are favored much more highly and items in lists that were made 3+ lists ago are virtually negligible to put more emphasis on newer trends.

Major point thresholds:
- 1: item appears in every single list
- 0.76: item appears in all lists, doesn't appear in exactly one list, and then appears again in current list
- 0.64: item appears in previous two lists
- 0.6: item appears in all lists except the current list
- 0.4: item appears only in the most recent list
- 0.36: item appears in all lists except the last two lists

In this model, it's very common for items to appear in the 0.3 - 0.6 range (vs. the previous was more spread out) which is why I've lowered the threshold to 0.4 for possible items to recommend.