### PR TITLE
Book Agent testing for authorized intents

### DIFF
--- a/portfolio/src/main/java/com/google/sps/agents/BooksAgent.java
+++ b/portfolio/src/main/java/com/google/sps/agents/BooksAgent.java
@@ -4,9 +4,14 @@ package com.google.sps.agents;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.users.UserService;
 import com.google.protobuf.Value;
+import com.google.sps.utils.BookUtils;
 import com.google.sps.utils.BooksAgentHelper;
+import com.google.sps.utils.OAuthHelper;
+import com.google.sps.utils.PeopleUtils;
 import java.io.IOException;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Books Agent handles user's requests for books from Google Books API. It determines appropriate
@@ -14,6 +19,7 @@ import java.util.Map;
  * intent.
  */
 public class BooksAgent implements Agent {
+  private static Logger log = LoggerFactory.getLogger(BooksAgent.class);
   private final String intentName;
   private BooksAgentHelper helper;
 
@@ -63,9 +69,69 @@ public class BooksAgent implements Agent {
       DatastoreService datastore,
       String queryID)
       throws IOException, IllegalArgumentException {
-    helper =
+    this(
+        intentName,
+        userInput,
+        parameters,
+        sessionID,
+        userService,
+        datastore,
+        queryID,
+        null,
+        null,
+        null);
+  }
+
+  /**
+   * BooksAgent constructor for testing purposes, specifying BooksAgentHelper object
+   *
+   * @param intentName String containing the specific intent within memory agent that user is
+   *     requesting.
+   * @param userInput String containing user's request input
+   * @param parameters Map containing the detected entities in the user's intent.
+   * @param sessionID String containing the unique sessionID for user's session
+   * @param userService UserService instance to access userID and other user info.
+   * @param datastore DatastoreService instance used to access book info grom database.
+   * @param queryID String containing the unique ID for the BookQuery the user is requesting, If
+   *     request comes from Book Display interface, then queryID is retrieved from Book Display
+   *     Otherwise, queryID is set to the most recent query that the user (sessionID) made.
+   * @param oauthHelper OAuthHelper instance used to access OAuth methods
+   * @param bookUtils BookUtils instance used to access Google Books API
+   * @param peopleUtils PeopleUtils instance used to access Google People API
+   */
+  public BooksAgent(
+      String intentName,
+      String userInput,
+      Map<String, Value> parameters,
+      String sessionID,
+      UserService userService,
+      DatastoreService datastore,
+      String queryID,
+      OAuthHelper oauthHelper,
+      BookUtils bookUtils,
+      PeopleUtils peopleUtils)
+      throws IOException, IllegalArgumentException {
+    if (oauthHelper == null) {
+      oauthHelper = new OAuthHelper();
+    }
+    if (bookUtils == null) {
+      bookUtils = new BookUtils();
+    }
+    if (peopleUtils == null) {
+      peopleUtils = new PeopleUtils();
+    }
+    this.helper =
         new BooksAgentHelper(
-            intentName, userInput, parameters, sessionID, userService, datastore, queryID);
+            intentName,
+            userInput,
+            parameters,
+            sessionID,
+            userService,
+            datastore,
+            queryID,
+            oauthHelper,
+            bookUtils,
+            peopleUtils);
     this.intentName = intentName;
     setParameters(parameters);
   }

--- a/portfolio/src/main/java/com/google/sps/data/Book.java
+++ b/portfolio/src/main/java/com/google/sps/data/Book.java
@@ -29,8 +29,7 @@ import java.util.ArrayList;
  * output display and text for the user
  *
  * <p>A Book object is only created by createBook() function, ensuring that any Book object is only
- * created with valid parameters and that all Book objects have valid title and description
- * properties.
+ * created with valid parameters and that all Book objects havea valid title property.
  */
 public class Book implements Serializable {
 
@@ -101,17 +100,13 @@ public class Book implements Serializable {
    * fields from the parameters. The rest of the properties will be set to an Empty String.
    *
    * @param title String title of book
-   * @param authors String authors of book
-   * @param description String description of book
-   * @param embeddable Bool indicating whether book is embeddable
-   * @param isbn String unique ISBN number
    */
-  public Book(String title, String authors, String description, Boolean embeddable, String isbn) {
+  public Book(String title) {
     this.title = title;
-    this.authors = authors;
-    this.description = description;
-    this.embeddable = embeddable;
-    this.isbn = isbn;
+    this.authors = "";
+    this.description = "";
+    this.embeddable = false;
+    this.isbn = "";
     this.publishedDate = "";
     this.averageRating = "";
     this.infoLink = "";
@@ -120,6 +115,46 @@ public class Book implements Serializable {
     this.textSnippet = "";
     this.volumeId = "";
     this.likedBy = new ArrayList<String>();
+  }
+
+  /**
+   * Public Book constructor, used for testing purposes with authors, description, embeddable, and
+   * order fields specified. The rest of the properties will be set to an Empty String.
+   *
+   * @param title String title of book
+   * @param authors String authors of book
+   * @param description String description of book
+   * @param embeddable Bool indicating whether book is embeddable
+   * @param isbn String unique ISBN number
+   * @param order order stored in datastore
+   */
+  public Book(
+      String title,
+      String authors,
+      String description,
+      Boolean embeddable,
+      String isbn,
+      int order) {
+    this(title);
+    this.authors = authors;
+    this.description = description;
+    this.embeddable = embeddable;
+    this.isbn = isbn;
+    this.order = order;
+  }
+
+  /**
+   * Public Book constructor, used for autenticated user testing purposes with volumeId and order
+   * properties specfied. The rest of the properties will be set to an Empty String.
+   *
+   * @param title String title of book
+   * @param volumeId unique volume ID for book within Google Books API
+   * @param order order stored in datastore
+   */
+  public Book(String title, String volumeId, int order) {
+    this(title);
+    this.volumeId = volumeId;
+    this.order = order;
   }
 
   @Override

--- a/portfolio/src/main/java/com/google/sps/data/BookComparator.java
+++ b/portfolio/src/main/java/com/google/sps/data/BookComparator.java
@@ -2,9 +2,12 @@ package com.google.sps.data;
 
 import java.util.Comparator;
 
-/* This class compares Book objects based on like count */
+/* This class compares Book objects based on like count, with ties broken alphabetically*/
 public class BookComparator implements Comparator<Book> {
   public int compare(Book firstBook, Book secondBook) {
+    if (secondBook.getLikeCount() - firstBook.getLikeCount() == 0) {
+      return (firstBook.getTitle()).compareTo(secondBook.getTitle());
+    }
     return secondBook.getLikeCount() - firstBook.getLikeCount();
   }
 }

--- a/portfolio/src/main/java/com/google/sps/utils/BooksMemoryUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/BooksMemoryUtils.java
@@ -27,8 +27,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.commons.lang3.SerializationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BooksMemoryUtils {
+  private static Logger log = LoggerFactory.getLogger(BooksMemoryUtils.class);
   /**
    * This function stores each Book object an ArrayList of Book objects in DataStore as a Book
    * Entity with the corresponding properties
@@ -187,6 +190,9 @@ public class BooksMemoryUtils {
    * @param sessionID unique id of session to retrieve from
    * @param queryID unique id (within sessionID) of query to store
    * @param datastore DatastoreService instance used to access Book info from database
+   * @param userService UserService instance to access userID and other user info.
+   * @param oauthHelper OAuthHelper instance used to access OAuth methods
+   * @param peopleUtils PeopleUtils instance used to access Google People API
    * @return ArrayList<Book>
    */
   public static ArrayList<Book> getStoredBooksToDisplay(
@@ -195,7 +201,9 @@ public class BooksMemoryUtils {
       String sessionID,
       String queryID,
       DatastoreService datastore,
-      UserService userService)
+      UserService userService,
+      OAuthHelper oauthHelper,
+      PeopleUtils peopleUtils)
       throws IOException {
     Filter idFilter = createSessionQueryFilter(sessionID, queryID);
     Query query = new Query("Book").setFilter(idFilter).addSort("order", SortDirection.ASCENDING);
@@ -204,7 +212,7 @@ public class BooksMemoryUtils {
     ArrayList<Book> friendsLikes = new ArrayList<Book>();
     if (userService.isUserLoggedIn()) {
       likedBooks = getLikedBooksFromId(sessionID, "id", datastore);
-      friendsLikes = getFriendsLikes(sessionID, datastore);
+      friendsLikes = getFriendsLikes(sessionID, datastore, oauthHelper, peopleUtils);
     }
 
     ArrayList<Book> books = new ArrayList<>();
@@ -322,7 +330,6 @@ public class BooksMemoryUtils {
     Gson gson = new Gson();
     Type listType = new TypeToken<ArrayList<String>>() {}.getType();
     ArrayList<String> names = gson.fromJson(listJson, listType);
-
     return names;
   }
 
@@ -463,11 +470,9 @@ public class BooksMemoryUtils {
    * This function stores a Book object and userEmail in a LikedBook entity in Datastore
    *
    * @param orderNum index of book to like
-   * @param startIndex index to start order at
-   * @param sessionID unique id of session to store
    * @param queryID unique id (within sessionID) of query to store
-   * @param datastore DatastoreService instance used to access Book info from database
    * @param userService UserService instance to access userID and other user info.
+   * @param datastore DatastoreService instance used to access Book info from database
    */
   public static void likeBook(
       int orderNum, String queryID, UserService userService, DatastoreService datastore) {
@@ -487,14 +492,33 @@ public class BooksMemoryUtils {
   }
 
   /**
+   * This function stores a Book object and userEmail in a LikedBook entity in Datastore
+   *
+   * @param bookToLike book to like
+   * @param userID unique id of user to store book for
+   * @param userEmail unique email of user to store liked book for
+   * @param datastore DatastoreService instance used to access Book info from database
+   */
+  public static void likeBook(
+      Book bookToLike, String userID, String userEmail, DatastoreService datastore) {
+    byte[] bookData = SerializationUtils.serialize(bookToLike);
+    Blob bookBlob = new Blob(bookData);
+
+    Entity likedBookEntity = new Entity("LikedBook");
+    likedBookEntity.setProperty("id", userID);
+    likedBookEntity.setProperty("userEmail", userEmail);
+    likedBookEntity.setProperty("volumeId", bookToLike.getVolumeId());
+    likedBookEntity.setProperty("book", bookBlob);
+    datastore.put(likedBookEntity);
+  }
+
+  /**
    * This function deletes a stored LikedBook Entity for the book and user specified in Datastore
    *
    * @param orderNum index of book to like
-   * @param startIndex index to start order at
-   * @param sessionID unique id of session to store
    * @param queryID unique id (within sessionID) of query to store
-   * @param datastore DatastoreService instance used to access Book info from database
    * @param userService UserService instance to access userID and other user info.
+   * @param datastore DatastoreService instance used to access Book info from database
    */
   public static void unlikeBook(
       int orderNum, String queryID, UserService userService, DatastoreService datastore) {
@@ -519,17 +543,44 @@ public class BooksMemoryUtils {
   }
 
   /**
+   * This function deletes a stored LikedBook Entity for the book and user specified in Datastore
+   *
+   * @param bookToUnlike book to unlike
+   * @param userID unique id of user to delete book for
+   * @param userEmail unique email of user to delete liked book for
+   * @param datastore DatastoreService instance used to access Book info from database
+   */
+  public static void unlikeBook(
+      Book bookToUnlike, String userID, String userEmail, DatastoreService datastore) {
+    String volumeID = bookToUnlike.getVolumeId();
+    Filter filter =
+        new CompositeFilter(
+            CompositeFilterOperator.AND,
+            Arrays.asList(
+                new FilterPredicate("id", FilterOperator.EQUAL, userID),
+                new FilterPredicate("volumeId", FilterOperator.EQUAL, volumeID)));
+    Query query = new Query("LikedBook").setFilter(filter);
+    PreparedQuery results = datastore.prepare(query);
+    for (Entity entity : results.asIterable()) {
+      datastore.delete(entity.getKey());
+    }
+  }
+
+  /**
    * This function returns a list of Book objects from the stored LikedBook Entities in Datastore
    * for all friends of the given userID
    *
    * @param userID unique id of user
    * @param datastore DatastoreService instance used to access Book info from database
+   * @param oauthHelper OAuthHelper instance used to access OAuth methods
+   * @param peopleUtils PeopleUtils instance used to access Google People API
    * @return ArrayList<Book> books liked by friends
    */
-  public static ArrayList<Book> getFriendsLikes(String userID, DatastoreService datastore)
+  public static ArrayList<Book> getFriendsLikes(
+      String userID, DatastoreService datastore, OAuthHelper oauthHelper, PeopleUtils peopleUtils)
       throws IOException {
     ArrayList<Book> friendsLikes = new ArrayList<Book>();
-    for (Friend friend : PeopleUtils.getFriends(userID)) {
+    for (Friend friend : peopleUtils.getFriends(userID, oauthHelper)) {
       for (String email : friend.getEmails()) {
         String name = friend.getName();
         if (!friend.hasName()) {
@@ -558,11 +609,18 @@ public class BooksMemoryUtils {
    * @param userID unique id of user
    * @param friendName name of friend to retrive liked books of
    * @param datastore DatastoreService instance used to access Book info from database
+   * @param oauthHelper OAuthHelper instance used to access OAuth methods
+   * @param peopleUtils PeopleUtils instance used to access Google People API
    * @return ArrayList<Book> books liked by friends
    */
   public static ArrayList<Book> getLikesOfFriend(
-      String userID, String friendName, DatastoreService datastore) throws IOException {
-    ArrayList<Book> friendsLikes = getFriendsLikes(userID, datastore);
+      String userID,
+      String friendName,
+      DatastoreService datastore,
+      OAuthHelper oauthHelper,
+      PeopleUtils peopleUtils)
+      throws IOException {
+    ArrayList<Book> friendsLikes = getFriendsLikes(userID, datastore, oauthHelper, peopleUtils);
     ArrayList<Book> individualFriendLikes = new ArrayList<Book>();
     for (Book likedBook : friendsLikes) {
       ArrayList<String> likedByLowerCase =

--- a/portfolio/src/main/java/com/google/sps/utils/OAuthHelper.java
+++ b/portfolio/src/main/java/com/google/sps/utils/OAuthHelper.java
@@ -88,6 +88,16 @@ public class OAuthHelper {
         .build();
   }
 
+  /**
+   * This function determines if the current user has stored book credentials
+   *
+   * @param userID ID of current user logged in
+   * @return boolean indicating if user has book credentials
+   */
+  public boolean hasBookAuthentication(String userID) throws IOException {
+    return (loadUserCredential(userID) != null);
+  }
+
   public static String getClientID() throws IOException {
     return new String(
         Files.readAllBytes(

--- a/portfolio/src/main/java/com/google/sps/utils/PeopleUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/PeopleUtils.java
@@ -25,10 +25,12 @@ public class PeopleUtils {
    *
    * @param userID ID for authenticated user
    * @param friendName friend to look for
+   * @param oauthHelper OAuthHelper instance used to access OAuth methods
    * @return boolean value
    */
-  public static Boolean hasFriend(String userID, String friendName) throws IOException {
-    for (Friend friend : getFriends(userID)) {
+  public Boolean hasFriend(String userID, String friendName, OAuthHelper oauthHelper)
+      throws IOException {
+    for (Friend friend : getFriends(userID, oauthHelper)) {
       if (friendName.toLowerCase().equals(friend.getName().toLowerCase())
           || friend.getEmails().contains(friendName)) {
         return true;
@@ -42,10 +44,11 @@ public class PeopleUtils {
    * People API and throws an exception otherwise
    *
    * @param userID ID for authenticated user
+   * @param helper OAuthHelper instance used to access OAuth methods
    * @return ArrayList<Friend> list of friends
    */
-  public static ArrayList<Friend> getFriends(String userID) throws IOException {
-    return getFriendList(getContactsFromAPI(userID));
+  public ArrayList<Friend> getFriends(String userID, OAuthHelper helper) throws IOException {
+    return getFriendList(getContactsFromAPI(userID, helper));
   }
 
   /**
@@ -55,7 +58,7 @@ public class PeopleUtils {
    * @param credential Valid credential for authenticated user
    * @return PeopleService object
    */
-  private static PeopleService getPeopleService(Credential credential) throws IOException {
+  private PeopleService getPeopleService(Credential credential) throws IOException {
     GsonFactory gsonFactory = new GsonFactory();
     UrlFetchTransport transport = new UrlFetchTransport();
     PeopleService service =
@@ -73,7 +76,7 @@ public class PeopleUtils {
    * @param connections list of Person objects from Google Books API
    * @return ArrayList<Friend>
    */
-  private static ArrayList<Friend> getFriendList(List<Person> connections) {
+  private ArrayList<Friend> getFriendList(List<Person> connections) {
     ArrayList<Friend> friends = new ArrayList<Friend>();
     if (connections != null && connections.size() > 0) {
       for (Person person : connections) {
@@ -92,11 +95,11 @@ public class PeopleUtils {
    * that match the authenticated user's bookshelves and throws an exception otherwise
    *
    * @param userID unique userID
+   * @param helper OAuthHelper instance used to access OAuth methods
    * @return Bookshelves object of results
    */
-  public static List<Person> getContactsFromAPI(String userID)
+  public List<Person> getContactsFromAPI(String userID, OAuthHelper helper)
       throws IOException, GoogleJsonResponseException {
-    OAuthHelper helper = new OAuthHelper();
     Credential credential = helper.loadUpdatedCredential(userID);
     PeopleService service = getPeopleService(credential);
     ListConnectionsResponse response =

--- a/portfolio/src/test/java/com/google/sps/BookAgentAuthIntentsTest.java
+++ b/portfolio/src/test/java/com/google/sps/BookAgentAuthIntentsTest.java
@@ -1,0 +1,604 @@
+package com.google.sps.agents;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.sps.data.Book;
+import com.google.sps.data.Friend;
+import com.google.sps.servlets.BookTestHelper;
+import com.google.sps.utils.BooksAgentHelper;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class runs JUnit tests to test BookAgent outputs for intents that require user to be logged
+ * in given mock BookUtils, PeopleUtils, and OAuthUtils instances to mock Google Books API, Google
+ * People API, and OAuth2.0
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class BookAgentAuthIntentsTest {
+
+  private static Logger log = LoggerFactory.getLogger(BookAgentAuthIntentsTest.class);
+  private BookTestHelper bookTester;
+  private ArrayList<Book> bookshelfBooks;
+  private ArrayList<String> bookshelves;
+  private ArrayList<Friend> friends;
+  private ArrayList<Book> friendsLikes;
+  private Book firstBook, secondBook, thirdBook, fourthBook, fifthBook, sixthBook;
+
+  /**
+   * Test setup which prepopulates the database and mocks with appropriate information about the
+   * authenticated user
+   */
+  @Before
+  public void setUp() throws ParseException, InvalidProtocolBufferException {
+    try {
+      // Set authenticated user
+      this.bookTester = new BookTestHelper();
+      bookTester.setLoggedIn("authUser1@gmail.com", "authUser1");
+      bookTester.setAuthenticatedUser("authUser1");
+
+      // Set user bookshelves and books in bookshelf for BookUtils mock
+      this.bookshelves =
+          new ArrayList<String>(
+              Arrays.asList(
+                  "My Google eBooks",
+                  "Purchased",
+                  "Reviewed",
+                  "Recently viewed",
+                  "Favorites",
+                  "Reading now",
+                  "To read",
+                  "Have read",
+                  "Books for you"));
+      bookTester.setBookshelfNames("authUser1", bookshelves);
+      this.bookshelfBooks = BookAgentTest.getBookList();
+      bookTester.setBookShelfBooks("authUser1", bookshelfBooks, 8);
+
+      // Set friends for PeopleUtils mock
+      this.friends = getFriendList();
+      bookTester.setFriends("authUser1", friends);
+
+      // Populize database with friend's liked books
+      setFriendsLikedBooks();
+
+      // Set the proper liked by properties for each book in the expected list of friends likes
+      // List will is sorted by like-count, ties broken alphabetically
+      firstBook.setLikedBy(new ArrayList<String>(Arrays.asList("John Doe", "Jim Jones")));
+      secondBook.setLikedBy(new ArrayList<String>(Arrays.asList("Mary Ann")));
+      thirdBook.setLikedBy(new ArrayList<String>(Arrays.asList("Jane Smith")));
+      fourthBook.setLikedBy(new ArrayList<String>(Arrays.asList("James Ray")));
+      fifthBook.setLikedBy(new ArrayList<String>(Arrays.asList("John Doe")));
+      sixthBook.setLikedBy(new ArrayList<String>(Arrays.asList("Jim Jones")));
+      friendsLikes =
+          new ArrayList<Book>(
+              Arrays.asList(firstBook, secondBook, thirdBook, fourthBook, fifthBook, sixthBook));
+
+      // Execute a library query for query-1-shelf in order to test followup intents for
+      // query-1-shelf
+      bookTester.setParameters(
+          "Show me my favorites bookshelves",
+          "{\"bookshelf\" : \"favorites\"}",
+          "library",
+          "authUser1",
+          "query-1-shelf",
+          "authUser1@gmail.com");
+
+      // Set bookshelf editing accesses for BookUtils mock to true
+      bookTester.setBookshelfEditingAccess("Favorites", "authUser1", true);
+
+    } catch (IllegalArgumentException | IOException e) {
+      Assert.fail("Should not have thrown any exception in set up.");
+    }
+  }
+
+  @After
+  public void deleteStoredInformation() {
+    clearDatabase();
+  }
+
+  /**
+   * This function tests a non-logged in user making a request for intents that require the user to
+   * give proper authentication
+   */
+  @Test
+  public void testUserNotLoggedIn() throws Exception {
+    bookTester.setLoggedOut();
+    bookTester.setParameters(
+        "Show me my bookshelves", "{}", "library", "unloggedInUser", "testEmail@gmail.com");
+    assertEquals("Please login first.", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests a logged in, but non-authenticated user making a request for intents that
+   * require the user to give proper authentication
+   */
+  @Test
+  public void testUserNotAuthenticated() throws Exception {
+    bookTester.setLoggedIn("testEmail@gmail.com", "unAuthenticatedUser");
+    bookTester.setParameters(
+        "Show me my bookshelves", "{}", "library", "unAuthenticatedUser", "testEmail@gmail.com");
+    assertEquals(
+        "Please allow me to access your Google Books and Contact information first.",
+        bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests a when a properly authenticated user makes a request for library intent,
+   * but does not specify which bookshelf in their library they would like to see in the parameters.
+   */
+  @Test
+  public void testLibraryIntentWithNoBookshelf() throws Exception {
+    bookTester.setParameters(
+        "Show me my bookshelves", "{}", "library", "authUser1", "authUser1@gmail.com");
+    String expectedOutput =
+        "[\"My Google eBooks\",\"Purchased\",\"Reviewed\",\"Recently viewed\",\"Favorites\",\"Reading now\",\"To read\",\"Have read\",\"Books for you\"]";
+    assertEquals("Which bookshelf would you like to see?", bookTester.getFulfillment());
+    assertEquals(expectedOutput, bookTester.getDisplay());
+    assertEquals("bookshelf-names", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, display, and redirect for a valid library request, requesting
+   * books from a bookshelf in the authenticated user's libary.
+   */
+  @Test
+  public void testValidLibraryIntent() throws Exception {
+    bookTester.setParameters(
+        "Show me my favorites bookshelves",
+        "{\"bookshelf\" : \"favorites\"}",
+        "library",
+        "authUser1",
+        "authUser1@gmail.com");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 0; i < 5; ++i) {
+      expectedList.add(bookshelfBooks.get(i));
+    }
+    String expectedOutput = BooksAgentHelper.listToJson(expectedList);
+    assertEquals("Here are the books in your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(expectedOutput, bookTester.getDisplay());
+    assertEquals("query-2-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a library intent when a user
+   * requests books from one of their bookshelves that contains no books.
+   */
+  @Test
+  public void testEmptyBookshelfLibraryIntent() throws Exception {
+    bookTester.setBookShelfBooks("authUser1", new ArrayList<Book>(), 0);
+    bookTester.setParameters(
+        "Show me my favorites bookshelves",
+        "{\"bookshelf\" : \"favorites\"}",
+        "library",
+        "authUser1",
+        "authUser1@gmail.com");
+    assertEquals("There are no books in your Favorites bookshelf.", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for an add intent, when a user
+   * requests to add a book to one of their bookshelves, but doesn't specify which bookshelf.
+   */
+  @Test
+  public void testAddIntentWithNoBookshelf() throws Exception {
+    bookTester.setParameters(
+        "Add Title 2 to my bookshelf",
+        "{\"number\" : 2}",
+        "add",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    String expectedOutput = "[\"Favorites\",\"Reading now\",\"To read\",\"Have read\"]";
+    assertEquals("Which bookshelf would you like to add Title 2 to?", bookTester.getFulfillment());
+    assertEquals(expectedOutput, bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful add intent when a
+   * user requests to add a book to one of their bookshelves and the Google Books API does so.
+   */
+  @Test
+  public void testSuccessfulAddIntent() throws Exception {
+    bookTester.setParameters(
+        "Add Title 2 to my bookshelf",
+        "{\"number\" : 2, \"bookshelf\" : \"favorites\"}",
+        "add",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    String expectedOutput = BooksAgentHelper.bookToJson(bookshelfBooks.get(2));
+    assertEquals("I've added Title 2 to your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(expectedOutput, bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a failed add intent when a user
+   * requests to add a book to one of their bookshelves and the Google Books API fails to do so.
+   */
+  @Test
+  public void testFailedAddIntent() throws Exception {
+    bookTester.setBookshelfEditingAccess("Favorites", "authUser1", false);
+    bookTester.setParameters(
+        "Add Title 2 to my favorites bookshelf",
+        "{\"number\" : 2, \"bookshelf\" : \"favorites\"}",
+        "add",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    String expectedOutput = BooksAgentHelper.bookToJson(bookshelfBooks.get(2));
+    assertEquals(
+        "I'm sorry. I couldn't add Title 2 to your Favorites bookshelf.",
+        bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a valid delete intent when a user
+   * requests to delete a book to one of their bookshelves and the Google Books API does so.
+   */
+  @Test
+  public void testSuccessfulDeleteIntent() throws Exception {
+    bookTester.setParameters(
+        "Delete Title 4 from my bookshelf",
+        "{\"number\" : 4, \"bookshelf\" : \"favorites\"}",
+        "delete",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    String expectedOutput = BooksAgentHelper.bookToJson(bookshelfBooks.get(4));
+    assertEquals(
+        "I've deleted Title 4 from your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(expectedOutput, bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a failed delete intent when a
+   * user requests to delete a book to one of their bookshelves and the Google Books API fails to do
+   * so.
+   */
+  @Test
+  public void testFailedDeleteIntent() throws Exception {
+    bookTester.setBookshelfEditingAccess("Favorites", "authUser1", false);
+    bookTester.setParameters(
+        "Delete Title 4 from my favorites bookshelf",
+        "{\"number\" : 4, \"bookshelf\" : \"favorites\"}",
+        "delete",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    assertEquals(
+        "I'm sorry. I couldn't delete Title 4 from your Favorites bookshelf.",
+        bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful friends intent when
+   * a user requests to see the books that their friends have liked.
+   */
+  @Test
+  public void testSuccessfulFriendsIntent() throws Exception {
+    bookTester.setParameters(
+        "What books do my friends like?", "{}", "friends", "authUser1", "authUser1@gmail.com");
+    assertEquals("Here are the books your friends like.", bookTester.getFulfillment());
+    ArrayList<Book> expectedFriendsLikesDisplay = new ArrayList<Book>();
+    for (int i = 0; i < 5; ++i) {
+      expectedFriendsLikesDisplay.add(friendsLikes.get(i));
+    }
+    assertEquals(BooksAgentHelper.listToJson(expectedFriendsLikesDisplay), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a friends intent when a user
+   * requests to see the books that their friends have liked, but their friends haven't liked any
+   * books.
+   */
+  @Test
+  public void testEmptyFriendsIntent() throws Exception {
+    // Unlike liked books for authUser1 friends
+    unlikeAllFriendsBooks();
+    bookTester.setParameters(
+        "What books do my friends like?", "{}", "friends", "authUser1", "authUser1@gmail.com");
+    assertEquals("I'm sorry. Your friends haven't liked any books.", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful mylikes intent when
+   * a user requests to see their own liked books.
+   */
+  @Test
+  public void testSuccessfulMyLikesIntent() throws Exception {
+    bookTester.setLikedBook(firstBook, "authUser1", "authUser1@gmail.com");
+    bookTester.setLikedBook(secondBook, "authUser1", "authUser1@gmail.com");
+    bookTester.setLikedBook(thirdBook, "authUser1", "authUser1@gmail.com");
+
+    // Set isLiked property for books in expectedLikes
+    firstBook.setIsLiked(true);
+    secondBook.setIsLiked(true);
+    thirdBook.setIsLiked(true);
+    ArrayList<Book> expectedLikes =
+        new ArrayList<Book>(Arrays.asList(firstBook, secondBook, thirdBook));
+
+    bookTester.setParameters(
+        "Show me my liked books", "{}", "mylikes", "authUser1", "authUser1@gmail.com");
+    assertEquals("Here are your liked books.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedLikes), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a mylikes intent when a user
+   * requests to see their own liked books, but they haven't liked any books.
+   */
+  @Test
+  public void testEmptyMyLikesIntent() throws Exception {
+    bookTester.setParameters(
+        "Show me my liked books", "{}", "mylikes", "authUser1", "authUser1@gmail.com");
+    assertEquals("You haven't liked any books yet!", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful friendlikes intent
+   * when a user requests to see the liked books of one of their friends, but doesn't specify a
+   * friend parameter.
+   */
+  @Test
+  public void testFriendLikesIntentInvalidParameter() throws Exception {
+    bookTester.setParameters(
+        "Show me my friend's likes",
+        "{\"friend\" : {\"name\": \"\"}}",
+        "friendlikes",
+        "authUser1",
+        "authUser1@gmail.com");
+    assertEquals("Which friend?", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful friendlikes intent
+   * when a user requests to see the liked books of one of their friends, but doesn't specify a name
+   * that is found in their list of friends.
+   */
+  @Test
+  public void testFriendLikesIntentInvalidName() throws Exception {
+    bookTester.setParameters(
+        "Show me Jimmy John's likes",
+        "{\"friend\" : {\"name\": \"Jimmy John\"}}",
+        "friendlikes",
+        "authUser1",
+        "authUser1@gmail.com");
+    assertEquals(
+        "I'm sorry. I don't recognize a Jimmy John in your contact list.",
+        bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a successful friendlikes intent
+   * when a user requests to see the liked books of one of their friends and their friends has
+   * stored likes.
+   */
+  @Test
+  public void testSuccessfulFriendLikesIntent() throws Exception {
+    bookTester.setParameters(
+        "Show me Jim Jones's liked books",
+        "{\"friend\" : {\"name\": \"jim jones's\"}}",
+        "friendlikes",
+        "authUser1",
+        "authUser1@gmail.com");
+
+    // Jim Jones likes first and sixth book, reset order of sixth book to 1 (first index in this
+    // list)
+    sixthBook.setOrder(1);
+    ArrayList<Book> expectedLikes = new ArrayList<Book>(Arrays.asList(firstBook, sixthBook));
+
+    assertEquals("Here are Jim Jones's liked books.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedLikes), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
+  }
+
+  /**
+   * This function tests the output, fulfillment, and redirect for a friendlikes intent when a user
+   * requests to see the liked books of one of their friends, but the friend hasn't liked any books.
+   */
+  @Test
+  public void testEmptyFriendLikesIntent() throws Exception {
+    bookTester.setParameters(
+        "Show me Claire Crown's liked books",
+        "{\"friend\" : {\"name\": \"claire crown's\"}}",
+        "friendlikes",
+        "authUser1",
+        "authUser1@gmail.com");
+
+    assertEquals("I couldn't find any liked books for Claire Crown.", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
+  }
+
+  /**
+   * Checks whether the output, display, and redirect when the user requests to see more books in
+   * one of their bookshelves
+   */
+  @Test
+  public void testNextPageOfBookshelfRequest() throws Exception {
+    bookTester.setParameters(
+        "Next page of my favorites bookshelf",
+        "{}",
+        "more",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 5; i < bookshelfBooks.size(); ++i) {
+      expectedList.add(bookshelfBooks.get(i));
+    }
+    assertEquals("Here's the next page of your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedList), bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * Checks whether the output, display, and redirect when the user requests to see more books in
+   * one of their bookshelves, but there are no more books to show.
+   */
+  @Test
+  public void testLastPageOfBookshelfRequest() throws Exception {
+    bookTester.setParameters(
+        "Next page of my favorites bookshelf",
+        "{}",
+        "more",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    bookTester.setParameters(
+        "Next page of my favorites bookshelf",
+        "{}",
+        "more",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 5; i < bookshelfBooks.size(); ++i) {
+      expectedList.add(bookshelfBooks.get(i));
+    }
+    assertEquals("This is the last page of your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedList), bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * Checks whether the output, display, and redirect when the user requests to see the previous
+   * page of books in one of their bookshelves.
+   */
+  @Test
+  public void testPreviousPageOfBookshelfRequest() throws Exception {
+    bookTester.setParameters(
+        "Next page of my favorites bookshelf",
+        "{}",
+        "more",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    bookTester.setParameters(
+        "Previous page of my favorites bookshelf",
+        "{}",
+        "previous",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 0; i < 5; ++i) {
+      expectedList.add(bookshelfBooks.get(i));
+    }
+    assertEquals(
+        "Here's the previous page of your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedList), bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  /**
+   * Checks whether the output, display, and redirect when the user requests to see the previous
+   * page of books in one of their bookshelves, but they are seeing the first page.
+   */
+  @Test
+  public void testFirstPageOfBookshelfRequest() throws Exception {
+    bookTester.setParameters(
+        "Previous page of my favorites bookshelf",
+        "{}",
+        "previous",
+        "authUser1",
+        "query-1-shelf",
+        "authUser1@gmail.com");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 0; i < 5; ++i) {
+      expectedList.add(bookshelfBooks.get(i));
+    }
+    assertEquals(
+        "This is the first page of your Favorites bookshelf.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedList), bookTester.getDisplay());
+    assertEquals("query-1-shelf", bookTester.getRedirect());
+  }
+
+  private ArrayList<Friend> getFriendList() {
+    ArrayList<Friend> friends = new ArrayList<Friend>();
+    friends.add(new Friend("John Doe", new ArrayList<String>(Arrays.asList("johndoe@gmail.com"))));
+    friends.add(new Friend("Jane Smith", new ArrayList<String>(Arrays.asList("jane@gmail.com"))));
+    friends.add(new Friend("James Ray", new ArrayList<String>(Arrays.asList("james@gmail.com"))));
+    friends.add(
+        new Friend(
+            "Jim Jones",
+            new ArrayList<String>(Arrays.asList("jimbo@gmail.com", "jimmy1@gmail.com"))));
+    friends.add(new Friend("Mary Ann", new ArrayList<String>(Arrays.asList("maryann@gmail.com"))));
+    friends.add(
+        new Friend("Claire Crown", new ArrayList<String>(Arrays.asList("clairec@gmail.com"))));
+    return friends;
+  }
+
+  private void setFriendsLikedBooks() {
+    this.firstBook = new Book("Dear John", "0", 0);
+    this.secondBook = new Book("Greece", "1", 1);
+    this.thirdBook = new Book("Love Actually", "2", 2);
+    this.fourthBook = new Book("Saving Alaska", "3", 3);
+    this.fifthBook = new Book("The Fault in our Stars", "4", 4);
+    this.sixthBook = new Book("The Notebook", "5", 5);
+
+    bookTester.setLikedBook(firstBook, "JohnDoe", "johndoe@gmail.com");
+    bookTester.setLikedBook(firstBook, "JimJones", "jimbo@gmail.com");
+    bookTester.setLikedBook(secondBook, "MaryAnn", "maryann@gmail.com");
+    bookTester.setLikedBook(secondBook, "RandomPerson1", "notafriend@gmail.com");
+    bookTester.setLikedBook(thirdBook, "RandomPerson2", "notafriend2@gmail.com");
+    bookTester.setLikedBook(thirdBook, "JaneSmith", "jane@gmail.com");
+    bookTester.setLikedBook(fourthBook, "JamesRay", "james@gmail.com");
+    bookTester.setLikedBook(fifthBook, "JohnDoe", "johndoe@gmail.com");
+    bookTester.setLikedBook(sixthBook, "JimJones", "jimmy1@gmail.com");
+    bookTester.setLikedBook(sixthBook, "JimJones", "jimbo@gmail.com");
+  }
+
+  private void unlikeAllFriendsBooks() {
+    bookTester.setUnlikedBook(firstBook, "JohnDoe", "johndoe@gmail.com");
+    bookTester.setUnlikedBook(firstBook, "JimJones", "jimbo@gmail.com");
+    bookTester.setUnlikedBook(secondBook, "MaryAnn", "maryann@gmail.com");
+    bookTester.setUnlikedBook(thirdBook, "JaneSmith", "jane@gmail.com");
+    bookTester.setUnlikedBook(fourthBook, "JamesRay", "james@gmail.com");
+    bookTester.setUnlikedBook(fifthBook, "JohnDoe", "johndoe@gmail.com");
+    bookTester.setUnlikedBook(sixthBook, "JimJones", "jimmy1@gmail.com");
+    bookTester.setUnlikedBook(sixthBook, "JimJones", "jimbo@gmail.com");
+  }
+
+  private void clearDatabase() {
+    bookTester.deleteFromCustomDatabase("unloggedInUser");
+    bookTester.deleteFromCustomDatabase("unAuthenticatedUser");
+    bookTester.deleteFromCustomDatabase("authUser1");
+    bookTester.deleteFromCustomDatabase("fallbackTestingID");
+  }
+}

--- a/portfolio/src/test/java/com/google/sps/BookAgentTest.java
+++ b/portfolio/src/test/java/com/google/sps/BookAgentTest.java
@@ -3,12 +3,9 @@ package com.google.sps.agents;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.google.protobuf.*;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.sps.data.Book;
-import com.google.sps.data.BookQuery;
-import com.google.sps.data.Output;
-import com.google.sps.servlets.BookAgentServlet;
-import com.google.sps.servlets.TestHelper;
+import com.google.sps.servlets.BookTestHelper;
 import com.google.sps.utils.BooksAgentHelper;
 import java.io.IOException;
 import java.text.ParseException;
@@ -30,9 +27,9 @@ import org.slf4j.LoggerFactory;
 public class BookAgentTest {
 
   private static Logger log = LoggerFactory.getLogger(BookAgentTest.class);
-  private TestHelper tester;
+  private BookTestHelper bookTester;
   private String parameters;
-  private ArrayList<Book> books;
+  private ArrayList<Book> books, expectedFirstPage, expectedSecondPage;
 
   /**
    * Test setup which prepopulates the database with a bunch of default sessionIDs to test database
@@ -41,141 +38,59 @@ public class BookAgentTest {
   @Before
   public void setUp() throws ParseException, InvalidProtocolBufferException {
     try {
-      parameters =
-          "{\"number\" : 3,"
-              + "\"order\" : \"\","
-              + "\"title\" : \"\","
-              + "\"type\" : \"book\","
-              + "\"authors\" : [],"
-              + "\"categories\" : \"love\","
-              + "\"language\" : \"\"}";
-      BookQuery query =
-          BookQuery.createBookQuery(
-              "search", "Books about love", BookAgentServlet.stringToMap(parameters));
-      tester = new TestHelper();
+      this.bookTester = new BookTestHelper();
+      this.parameters = "{\"number\" : 3," + "\"type\" : \"book\"," + "\"categories\" : \"love\"}";
 
-      // Pre-populate database for testSession1, testQuery1: invalid previous and valid more
-      tester.setCustomDatabase( // startIndex
-          0,
-          // totalResults
-          15,
-          // resultsStored
-          10,
-          // displayNum
-          5,
-          // sessionID
-          "testSession1",
-          // queryID
-          "testQuery1");
-      tester.setCustomDatabase(query, "testSession1", "testQuery1");
-
-      // Pre-populate database for testSession2, testQuery2: valid previous and invalid more
-      tester.setCustomDatabase( // startIndex
-          10,
-          // totalResults
-          10,
-          // resultsStored
-          10,
-          // displayNum
-          5,
-          // sessionID
-          "testSession2",
-          // queryID
-          "testQuery2");
-      tester.setCustomDatabase(query, "testSession2", "testQuery2");
-
-      // Pre-populate database for testSession2, testQuery3: valid previous and valid more
-      tester.setCustomDatabase( // startIndex
-          8,
-          // totalResults
-          200,
-          // resultsStored
-          10,
-          // displayNum
-          5,
-          // sessionID
-          "testSession1",
-          // queryID
-          "testQuery3");
-      tester.setCustomDatabase(query, "testSession1", "testQuery3");
-
-      // Pre-populate database with Books for testSession3, testSession2
-      tester.setCustomDatabase( // startIndex
-          0,
-          // totalResults
-          5,
-          // resultsStored
-          5,
-          // displayNum
-          5,
-          // sessionID
-          "testSession3",
-          // queryID
-          "testQuery1");
-      tester.setCustomDatabase(query, "testSession3", "testQuery1");
-      books = new ArrayList<Book>();
-      books.add(new Book("Title 0", "Author 0a, Author 0b", "Description 0", true, "isbn0"));
-      books.add(new Book("Title 1", "Author 1a, Author 1b", "Description 1", true, "isbn1"));
-      books.add(new Book("Title 2", "Author 2a, Author 2b", "Description 2", true, "isbn2"));
-      books.add(new Book("Title 3", "Author 3a, Author 3b", "Description 3", true, "isbn3"));
-      books.add(new Book("Title 4", "Author 4a, Author 4b", "Description 4", true, "isbn4"));
-      tester.setCustomDatabase(books, 0, "testSession3", "testQuery1");
+      this.bookTester = new BookTestHelper();
+      this.books = getBookList();
+      this.expectedFirstPage = new ArrayList<Book>();
+      for (int i = 0; i < 5; ++i) {
+        expectedFirstPage.add(books.get(i));
+      }
+      this.expectedSecondPage = new ArrayList<Book>();
+      for (int i = 5; i < books.size(); ++i) {
+        expectedSecondPage.add(books.get(i));
+      }
+      // Initializes query-1 in database for testUser1 (books list is result)
+      bookTester.setSearchBooks(books, 8);
+      bookTester.setParameters("Books about frogs", parameters, "search", "testUser1");
     } catch (IOException | IllegalArgumentException e) {
-      Assert.fail(
-          "Should not have thrown any exception in set up valid BookQuery, Books and Indices set up.");
+      Assert.fail("Should not have thrown any exception in set up.");
     }
   }
 
   @After
   public void deleteStoredInformation() {
-    tester.deleteFromCustomDatabase("testSession1");
-    tester.deleteFromCustomDatabase("testSession2");
-    tester.deleteFromCustomDatabase("testSession3");
-    tester.deleteFromCustomDatabase("fallbackTestingID");
+    bookTester.deleteFromCustomDatabase("testUser1");
   }
 
   /**
-   * Checks that if the user query is invalid (i.e. one the Google Books API does not contain a
-   * single match with), then the fulfillment is appropriate and no display is made.
+   * Checks that if the user's search query is invalid (i.e. one the Google Books API does not
+   * contain a single match with), then the fulfillment is appropriate and no display is made.
    */
   @Test
-  public void testEmptyQuery() throws Exception {
-    tester.setParameters(
-        "Books by abby mapes",
-        "{\"order\" : \"\","
-            + "\"title\" : \"\","
-            + "\"type\" : \"book\","
-            + "\"authors\" : [{\"name\": \"abby mapes\"}],"
-            + "\"categories\" : \"\","
-            + "\"language\" : \"\"}",
-        "books.search");
-    tester.setLoggedOut();
-    Output output = tester.getOutput();
-    assertEquals("I couldn't find any results. Can you try again?", output.getFulfillmentText());
-    assertNull(output.getDisplay());
-    assertNull(output.getRedirect());
+  public void testFailedSearchIntent() throws Exception {
+    bookTester.setSearchBooks(new ArrayList<Book>(), 0);
+    bookTester.setParameters("Books by abby mapes", parameters, "search", "testUser1");
+    assertEquals("I couldn't find any results. Can you try again?", bookTester.getFulfillment());
+    assertNull(bookTester.getDisplay());
+    assertNull(bookTester.getRedirect());
   }
 
   /**
-   * Checks that if the user books search query is valid, then the fulfillment is appropriate, and
-   * both a redirect and display are made.
+   * Checks that if the user books search query is valid, then the output, display, and redirect is
+   * correct.
    */
   @Test
-  public void testSearchQuery() throws Exception {
-    tester.setParameters(
-        "Books about puppies",
-        "{\"order\" : \"\","
-            + "\"title\" : \"\","
-            + "\"type\" : \"book\","
-            + "\"authors\" : [],"
-            + "\"categories\" : \"puppies\","
-            + "\"language\" : \"\"}",
-        "books.search");
-    tester.setLoggedOut();
-    Output output = tester.getOutput();
-    assertEquals("Here's what I found.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertNotNull(output.getRedirect());
+  public void testSuccessfulSearchIntent() throws Exception {
+    bookTester.setParameters("Books about frogs", parameters, "search", "testUser1");
+    ArrayList<Book> expectedList = new ArrayList<Book>();
+    for (int i = 0; i < 5; ++i) {
+      expectedList.add(books.get(i));
+    }
+    assertEquals("Here's what I found.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedFirstPage), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
   }
 
   /**
@@ -185,10 +100,11 @@ public class BookAgentTest {
    */
   @Test
   public void testInvalidPreviousRequest() throws Exception {
-    Output output = tester.getOutput("books.previous", "testSession1", parameters, "testQuery1");
-    assertEquals("This is the first page of results.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertEquals("testQuery1", output.getRedirect());
+    bookTester.setParameters(
+        "previous page", parameters, "previous", "testUser1", "query-1", "test@example.com");
+    assertEquals("This is the first page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedFirstPage), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /**
@@ -198,10 +114,13 @@ public class BookAgentTest {
    */
   @Test
   public void testValidPreviousRequest() throws Exception {
-    Output output = tester.getOutput("books.previous", "testSession2", parameters, "testQuery2");
-    assertEquals("Here's the previous page of results.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertEquals("testQuery2", output.getRedirect());
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-1", "test@example.com");
+    bookTester.setParameters(
+        "previous page", parameters, "previous", "testUser1", "query-1", "test@example.com");
+    assertEquals("Here's the previous page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedFirstPage), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /**
@@ -211,10 +130,13 @@ public class BookAgentTest {
    */
   @Test
   public void testInvalidMoreRequestCase() throws Exception {
-    Output output = tester.getOutput("books.more", "testSession2", parameters, "testQuery2");
-    assertEquals("This is the last page of results.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertEquals("testQuery2", output.getRedirect());
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-1", "test@example.com");
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-1", "test@example.com");
+    assertEquals("This is the last page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedSecondPage), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /**
@@ -222,14 +144,15 @@ public class BookAgentTest {
    * show. In this case, the fulfillment indicates that it is showing the next page, and both a
    * redirect and display are made.
    *
-   * <p>Checks the case where (startIndex + displayNum <= resultsStored)
+   * <p>Checks the case where (startIndex + displayNum >= totalResults)
    */
   @Test
   public void testValidMoreRequestCase1() throws Exception {
-    Output output = tester.getOutput("books.more", "testSession1", parameters, "testQuery1");
-    assertEquals("Here's the next page of results.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertEquals("testQuery1", output.getRedirect());
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-1", "test@example.com");
+    assertEquals("Here's the next page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedSecondPage), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /**
@@ -241,28 +164,64 @@ public class BookAgentTest {
    */
   @Test
   public void testValidMoreRequestCase2() throws Exception {
-    Output output = tester.getOutput("books.more", "testSession1", parameters, "testQuery3");
-    assertEquals("Here's the next page of results.", output.getFulfillmentText());
-    assertNotNull(output.getDisplay());
-    assertEquals("testQuery3", output.getRedirect());
+    bookTester.setSearchBooks(books, 16);
+    bookTester.setParameters("Books about history", parameters, "search", "testUser1");
+    // Makes call to API to retrieve more results
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-2", "test@example.com");
+    ArrayList<Book> expectedResults = getExpectedBookList();
+    assertEquals("Here's the next page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedResults), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
+  }
+
+  /**
+   * Checks requesting the next page of a Book search query when there are more result pages to
+   * show. In this case, the fulfillment indicates that it is showing the next page, and both a
+   * redirect and display are made.
+   *
+   * <p>Checks the case where (startIndex + displayNum = resultsStored)
+   */
+  @Test
+  public void testValidMoreRequestCase3() throws Exception {
+    books.add(new Book("Title 8", "Author 8a, Author 8b", "Description 8", true, "isbn6", 8));
+    books.add(new Book("Title 9", "Author 9a, Author 9b", "Description 9", true, "isbn9", 9));
+    bookTester.setSearchBooks(books, 10);
+    bookTester.setParameters("Books about history", parameters, "search", "testUser1");
+    bookTester.setParameters(
+        "next page", parameters, "more", "testUser1", "query-2", "test@example.com");
+    ArrayList<Book> expectedResults = new ArrayList<Book>();
+    for (int i = 5; i < books.size(); ++i) {
+      expectedResults.add(books.get(i));
+    }
+    assertEquals("Here's the next page of results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedResults), bookTester.getDisplay());
+    assertEquals("query-2", bookTester.getRedirect());
   }
 
   /** Checks requesting the description of a certain book, from parameter number. */
   @Test
   public void testBookDescription() throws Exception {
-    Output output = tester.getOutput("books.description", "testSession3", parameters, "testQuery1");
-    assertEquals("Here's a description of Title 3.", output.getFulfillmentText());
-    assertEquals(BooksAgentHelper.bookToJson(books.get(3)), output.getDisplay());
-    assertEquals("testQuery1", output.getRedirect());
+    bookTester.setParameters(
+        "description of title 3",
+        parameters,
+        "description",
+        "testUser1",
+        "query-1",
+        "test@example.com");
+    assertEquals("Here's a description of Title 3.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.bookToJson(books.get(3)), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /** Checks requesting the preview of a certain book, from parameter number. */
   @Test
   public void testBookPreview() throws Exception {
-    Output output = tester.getOutput("books.preview", "testSession3", parameters, "testQuery1");
-    assertEquals("Here's a preview of Title 3.", output.getFulfillmentText());
-    assertEquals(BooksAgentHelper.bookToJson(books.get(3)), output.getDisplay());
-    assertEquals("testQuery1", output.getRedirect());
+    bookTester.setParameters(
+        "preview of title 3", parameters, "preview", "testUser1", "query-1", "test@example.com");
+    assertEquals("Here's a preview of Title 3.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.bookToJson(books.get(3)), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
   }
 
   /**
@@ -270,9 +229,35 @@ public class BookAgentTest {
    */
   @Test
   public void testBookResults() throws Exception {
-    Output output = tester.getOutput("books.results", "testSession3", parameters, "testQuery1");
-    assertEquals("Here are the results.", output.getFulfillmentText());
-    assertEquals(BooksAgentHelper.listToJson(books), output.getDisplay());
-    assertEquals("testQuery1", output.getRedirect());
+    bookTester.setParameters(
+        "back to results", parameters, "results", "testUser1", "query-1", "test@example.com");
+    assertEquals("Here are the results.", bookTester.getFulfillment());
+    assertEquals(BooksAgentHelper.listToJson(expectedFirstPage), bookTester.getDisplay());
+    assertEquals("query-1", bookTester.getRedirect());
+  }
+
+  private ArrayList<Book> getExpectedBookList() {
+    ArrayList<Book> expectedResults = expectedSecondPage;
+    expectedResults.add(books.get(0));
+    expectedResults.add(books.get(1));
+    expectedResults.get(0).setOrder(5);
+    expectedResults.get(1).setOrder(6);
+    expectedResults.get(2).setOrder(7);
+    expectedResults.get(3).setOrder(8);
+    expectedResults.get(4).setOrder(9);
+    return expectedResults;
+  }
+
+  public static ArrayList<Book> getBookList() {
+    ArrayList<Book> books = new ArrayList<Book>();
+    books.add(new Book("Title 0", "Author 0a, Author 0b", "Description 0", true, "isbn0", 0));
+    books.add(new Book("Title 1", "Author 1a, Author 1b", "Description 1", true, "isbn1", 1));
+    books.add(new Book("Title 2", "Author 2a, Author 2b", "Description 2", true, "isbn2", 2));
+    books.add(new Book("Title 3", "Author 3a, Author 3b", "Description 3", true, "isbn3", 3));
+    books.add(new Book("Title 4", "Author 4a, Author 4b", "Description 4", true, "isbn4", 4));
+    books.add(new Book("Title 5", "Author 5a, Author 5b", "Description 5", true, "isbn5", 5));
+    books.add(new Book("Title 6", "Author 6a, Author 6b", "Description 6", true, "isbn6", 6));
+    books.add(new Book("Title 7", "Author 7a, Author 7b", "Description 7", true, "isbn7", 7));
+    return books;
   }
 }

--- a/portfolio/src/test/java/com/google/sps/BookTestHelper.java
+++ b/portfolio/src/test/java/com/google/sps/BookTestHelper.java
@@ -1,0 +1,343 @@
+package com.google.sps.servlets;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.testing.json.MockJsonFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.sps.agents.BooksAgent;
+import com.google.sps.data.Book;
+import com.google.sps.data.BookQuery;
+import com.google.sps.data.Friend;
+import com.google.sps.utils.BookUtils;
+import com.google.sps.utils.BooksMemoryUtils;
+import com.google.sps.utils.OAuthHelper;
+import com.google.sps.utils.PeopleUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.mockito.Mock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BookTestHelper {
+  private static Logger log = LoggerFactory.getLogger(BookTestHelper.class);
+  @Mock UserService userServiceMock;
+  @Mock OAuthHelper oauthHelperMock;
+  @Mock PeopleUtils peopleUtilsMock;
+  @Mock BookUtils bookUtilsMock;
+
+  BooksAgent booksAgent;
+  DatastoreService customDatastore;
+  String sessionId;
+  String queryId;
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  /** Default constructor for BookTestHelper that sets up testing environment and empty mocks. */
+  public BookTestHelper() {
+    helper.setUp();
+    customDatastore = DatastoreServiceFactory.getDatastoreService();
+    userServiceMock = mock(UserService.class);
+    oauthHelperMock = mock(OAuthHelper.class);
+    peopleUtilsMock = mock(PeopleUtils.class);
+    bookUtilsMock = mock(BookUtils.class);
+    this.sessionId = "fallbackTestingID";
+    this.queryId = null;
+  }
+
+  /**
+   * Sets the general return parameters to mock OAuthHelper when userEmail and queryId are not
+   * specified, i.e. for an un-authenticated query request
+   *
+   * @param inputText Text input of user's intent sent to Dialogflow.
+   * @param parameters String json that consists of expected parameters identified by Dialogflow.
+   * @param intentName String name of expected intent identified by Dialogflow.
+   * @param sessionId String unique ID for current session
+   */
+  public void setParameters(
+      String inputText, String parameters, String intentName, String sessionId)
+      throws InvalidProtocolBufferException, IOException {
+    setParameters(inputText, parameters, intentName, sessionId, null, null);
+  }
+
+  /**
+   * Sets the general return parameters to mock OAuthHelper when queryId is not specified, i.e. for
+   * a new query request
+   *
+   * @param inputText Text input of user's intent sent to Dialogflow.
+   * @param parameters String json that consists of expected parameters identified by Dialogflow.
+   * @param intentName String name of expected intent identified by Dialogflow.
+   * @param sessionId String unique ID for current session
+   * @param userEmail email associated with user ID
+   */
+  public void setParameters(
+      String inputText, String parameters, String intentName, String sessionId, String userEmail)
+      throws InvalidProtocolBufferException, IOException {
+    setParameters(inputText, parameters, intentName, sessionId, null, userEmail);
+  }
+
+  /**
+   * Sets the parameters for BookAgent instance.
+   *
+   * @param inputText Text input of user's intent sent to Dialogflow.
+   * @param parameters String json that consists of expected parameters identified by Dialogflow.
+   * @param intentName String name of expected intent identified by Dialogflow.
+   * @param sessionId String unique ID for current session
+   * @param queryId String unique ID for current query
+   * @param userEmail email associated with user ID
+   */
+  public void setParameters(
+      String inputText,
+      String parameters,
+      String intentName,
+      String sessionId,
+      String queryId,
+      String userEmail)
+      throws InvalidProtocolBufferException, IOException {
+    this.sessionId = sessionId;
+    this.queryId = queryId;
+    booksAgent =
+        new BooksAgent(
+            intentName,
+            inputText,
+            BookAgentServlet.stringToMap(parameters),
+            sessionId,
+            userServiceMock,
+            customDatastore,
+            queryId,
+            oauthHelperMock,
+            bookUtilsMock,
+            peopleUtilsMock);
+  }
+
+  public String getFulfillment() {
+    return booksAgent.getOutput();
+  }
+
+  public String getDisplay() {
+    return booksAgent.getDisplay();
+  }
+
+  public String getRedirect() {
+    return booksAgent.getRedirect();
+  }
+
+  /**
+   * Sets list of Friend objects for a user returned from PeopleUtils mock when a user requests
+   * their friends' likes and sets hasFriend to return true if the name is included in the list of
+   * Friend objects. Otherwise, hasFriend will return false.
+   *
+   * @param userId unique Id of user
+   * @param friends list of Friend objects
+   */
+  public void setFriends(String userID, ArrayList<Friend> friends) throws IOException {
+    when(peopleUtilsMock.getFriends(eq(userID), any(OAuthHelper.class))).thenReturn(friends);
+    when(peopleUtilsMock.hasFriend(eq(userID), any(String.class), any(OAuthHelper.class)))
+        .thenReturn(false);
+    for (Friend friend : friends) {
+      when(peopleUtilsMock.hasFriend(eq(userID), eq(friend.getName()), any(OAuthHelper.class)))
+          .thenReturn(true);
+    }
+  }
+
+  /**
+   * Sets the list of bookshelf names returned from the BookUtils mock when a user requests
+   * bookshelves from their libraries
+   *
+   * @param userId unique Id of user
+   * @param bookshelfNames list of Bookshelf names
+   */
+  public void setBookshelfNames(String userId, ArrayList<String> bookshelfNames)
+      throws IOException {
+    when(bookUtilsMock.getBookshelvesNames(eq(userId), any(OAuthHelper.class)))
+        .thenReturn(bookshelfNames);
+  }
+
+  /**
+   * Sets BookUtils mock to edit the users bookshelf (add or delete), or fail to add the book to the
+   * user's bookshelf and throw a GoogleJsonResponseException
+   *
+   * @param bookshelfName name of bookshelf to edit
+   * @param userId unique Id of user
+   * @param allowEditing boolean determining whether BookUtilsMock throws exception, indicating it
+   *     could not edit user's bookshelf, or edits the user's bookshelf and returns nothing
+   */
+  public void setBookshelfEditingAccess(String bookshelfName, String userId, Boolean allowEditing)
+      throws IOException {
+    JsonFactory jsonFactory = new MockJsonFactory();
+    GoogleJsonResponseException testException =
+        GoogleJsonResponseExceptionFactoryTesting.newMock(
+            jsonFactory, HttpStatusCodes.STATUS_CODE_FORBIDDEN, "Test Exception");
+    if (allowEditing) {
+      doNothing()
+          .when(bookUtilsMock)
+          .addToBookshelf(eq(bookshelfName), eq(userId), any(String.class), any(OAuthHelper.class));
+      doNothing()
+          .when(bookUtilsMock)
+          .deleteFromBookshelf(
+              eq(bookshelfName), eq(userId), any(String.class), any(OAuthHelper.class));
+    } else {
+      doThrow(testException)
+          .when(bookUtilsMock)
+          .addToBookshelf(eq(bookshelfName), eq(userId), any(String.class), any(OAuthHelper.class));
+      doThrow(testException)
+          .when(bookUtilsMock)
+          .deleteFromBookshelf(
+              eq(bookshelfName), eq(userId), any(String.class), any(OAuthHelper.class));
+    }
+  }
+
+  /**
+   * Sets the list of books returned from the BookUtils mock when a user requests books from their
+   * authenticated bookshelf
+   *
+   * @param userId unique Id of user
+   * @param bookshelfBooks list of Book objects
+   * @param totalBooksFound number of books in certain bookshelf
+   */
+  public void setBookShelfBooks(String userId, ArrayList<Book> bookshelfBooks, int totalBooksFound)
+      throws IOException {
+    when(bookUtilsMock.getBookShelfBooks(
+            any(BookQuery.class), anyInt(), eq(userId), any(OAuthHelper.class)))
+        .thenReturn(bookshelfBooks);
+    when(bookUtilsMock.getTotalShelfVolumesFound(
+            any(BookQuery.class), anyInt(), eq(userId), any(OAuthHelper.class)))
+        .thenReturn(totalBooksFound);
+  }
+
+  /**
+   * Sets the list of books returned from the BookUtils mock when a user makes a generic book search
+   *
+   * @param books list of Book objects
+   * @param totalBooksFound number of books in certain bookshelf
+   */
+  public void setSearchBooks(ArrayList<Book> books, int totalBooksFound) throws IOException {
+    when(bookUtilsMock.getRequestedBooks(any(BookQuery.class), anyInt())).thenReturn(books);
+    when(bookUtilsMock.getTotalVolumesFound(any(BookQuery.class), anyInt()))
+        .thenReturn(totalBooksFound);
+  }
+
+  /**
+   * Sets the mocks returned for a logged-in user with email and id from parameters
+   *
+   * @param email email of logged-in user
+   * @param id id of logged-in user
+   */
+  public void setLoggedIn(String email, String id) {
+    setUser(email, id);
+  }
+
+  /**
+   * Sets the mocks returned for authenticated users
+   *
+   * @param id id of logged-in user
+   */
+  public void setAuthenticatedUser(String id) throws IOException {
+    when(oauthHelperMock.hasBookAuthentication(id)).thenReturn(true);
+  }
+
+  /** Sets the user service mock to return a logged-out user. */
+  public void setLoggedOut() {
+    when(userServiceMock.isUserLoggedIn()).thenReturn(false);
+  }
+
+  /**
+   * Creates a customized user.
+   *
+   * @param email String containing the user's email.
+   * @param id String containing the user's id number.
+   */
+  public void setUser(String email, String id) {
+    when(userServiceMock.isUserLoggedIn()).thenReturn(true);
+    when(userServiceMock.getCurrentUser()).thenReturn(new User(email, "authDomain", id));
+  }
+
+  /**
+   * This function adds a liked book for a user from the customDatastore.
+   *
+   * @param book book to like
+   * @param userID unique id of user to add book for
+   * @param userEmail unique email of user to add liked book for
+   */
+  public void setLikedBook(Book book, String userID, String userEmail) {
+    BooksMemoryUtils.likeBook(book, userID, userEmail, customDatastore);
+  }
+
+  /**
+   * This function deletes a liked book for a user from the customDatastore.
+   *
+   * @param book book to unlike
+   * @param userID unique id of user to delete book for
+   * @param userEmail unique email of user to delete liked book for
+   */
+  public void setUnlikedBook(Book book, String userID, String userEmail) {
+    BooksMemoryUtils.unlikeBook(book, userID, userEmail, customDatastore);
+  }
+
+  /**
+   * Populates customizes datastore with desired BookQuery object.
+   *
+   * @param query BookQuery object to store
+   * @param sessionId unique id of session to store
+   * @param queryId unique id (within sessionId) of query to store
+   */
+  public void setCustomDatabase(BookQuery query, String sessionId, String queryId) {
+    BooksMemoryUtils.storeBookQuery(query, sessionId, queryId, customDatastore);
+  }
+
+  /**
+   * Populates customizes datastore with desired Indices parameters, used to construct an indices
+   * object.
+   *
+   * @param startIndex index to start retrieving Volume objects from
+   * @param resultsStored number of results stored
+   * @param totalResults total matches in Google Book API
+   * @param displayNum number of results displayed request
+   * @param sessionId unique id of session to store
+   * @param queryId unique id (within sessionId) of query to store
+   */
+  public void setCustomDatabase(
+      int startIndex,
+      int totalResults,
+      int resultsStored,
+      int displayNum,
+      String sessionId,
+      String queryId) {
+    BooksMemoryUtils.storeIndices(
+        startIndex, totalResults, resultsStored, displayNum, sessionId, queryId, customDatastore);
+  }
+
+  /**
+   * Populates customizes datastore with desired Books, starting at startIndex.
+   *
+   * @param books ArrayList of Book objects to store
+   * @param startIndex index to start order at
+   * @param sessionId unique id of session to store
+   * @param queryId unique id (within sessionId) of query to store
+   */
+  public void setCustomDatabase(
+      ArrayList<Book> books, int startIndex, String sessionId, String queryId) {
+    BooksMemoryUtils.storeBooks(books, startIndex, sessionId, queryId, customDatastore);
+  }
+
+  /**
+   * Clears all stored book information for sessionId from custom datastore.
+   *
+   * @param sessionId unique id of session to delete stored information from
+   */
+  public void deleteFromCustomDatabase(String sessionId) {
+    BooksMemoryUtils.deleteAllStoredBookInformation(sessionId, customDatastore);
+  }
+}

--- a/portfolio/src/test/java/com/google/sps/MapsSearchTest.java
+++ b/portfolio/src/test/java/com/google/sps/MapsSearchTest.java
@@ -246,7 +246,8 @@ public class MapsSearchTest {
     // Assertions
     assertEquals(
         "Here is the map for: 500 W 2nd St, Austin, TX 78701, USA", output.getFulfillmentText());
-    assertEquals("{\"limit\":-1,\"lng\":-97.7495642,\"lat\":30.2660754}", output.getDisplay());
+    assertEquals(
+        "{\"limit\":-1,\"lng\":-97.74955949999999,\"lat\":30.2660766}", output.getDisplay());
   }
 
   @Test

--- a/portfolio/src/test/java/com/google/sps/TestHelper.java
+++ b/portfolio/src/test/java/com/google/sps/TestHelper.java
@@ -142,29 +142,6 @@ public class TestHelper {
   }
 
   /**
-   * Gets the output object created by agent fulfillment after at the end of back-end process.
-   *
-   * @param intent intent String passed as parameter to Servlet
-   * @param sessionID unique ID for current session
-   * @param parameterMap String containing parameters needed, if any, by BookAgent
-   * @param queryID unique ID (within sessionID) for current query
-   * @return Output object identical to that which is passed back to javascript.
-   */
-  public Output getOutput(String intent, String sessionID, String parameterMap, String queryID)
-      throws InvalidProtocolBufferException {
-    BookAgentServlet bookServlet = new BookAgentServlet();
-    Output output =
-        bookServlet.getOutputFromBookAgent(
-            intent,
-            sessionID,
-            BookAgentServlet.stringToMap(parameterMap),
-            "en-US",
-            queryID,
-            customDatastore);
-    return output;
-  }
-
-  /**
    * Sets the input text to mock http request.
    *
    * @param inputText Text input of user's intent sent to Dialogflow.
@@ -259,61 +236,6 @@ public class TestHelper {
    */
   public void setCustomDatabase(String listName, ArrayList<String> items, long startTime) {
     MemoryUtils.makeListEntity(customDatastore, "1", items, listName, startTime);
-  }
-
-  /**
-   * Populates customizes datastore with desired BookQuery object.
-   *
-   * @param query BookQuery object to store
-   * @param sessionID unique id of session to store
-   * @param queryID unique id (within sessionID) of query to store
-   */
-  public void setCustomDatabase(BookQuery query, String sessionID, String queryID) {
-    BooksMemoryUtils.storeBookQuery(query, sessionID, queryID, customDatastore);
-  }
-
-  /**
-   * Populates customizes datastore with desired Indices parameters, used to construct an indices
-   * object.
-   *
-   * @param startIndex index to start retrieving Volume objects from
-   * @param resultsStored number of results stored
-   * @param totalResults total matches in Google Book API
-   * @param displayNum number of results displayed request
-   * @param sessionID unique id of session to store
-   * @param queryID unique id (within sessionID) of query to store
-   */
-  public void setCustomDatabase(
-      int startIndex,
-      int totalResults,
-      int resultsStored,
-      int displayNum,
-      String sessionID,
-      String queryID) {
-    BooksMemoryUtils.storeIndices(
-        startIndex, totalResults, resultsStored, displayNum, sessionID, queryID, customDatastore);
-  }
-
-  /**
-   * Populates customizes datastore with desired Books, starting at startIndex.
-   *
-   * @param books ArrayList of Book objects to store
-   * @param startIndex index to start order at
-   * @param sessionID unique id of session to store
-   * @param queryID unique id (within sessionID) of query to store
-   */
-  public void setCustomDatabase(
-      ArrayList<Book> books, int startIndex, String sessionID, String queryID) {
-    BooksMemoryUtils.storeBooks(books, startIndex, sessionID, queryID, customDatastore);
-  }
-
-  /**
-   * Clears all stored book information for sessionID from custom datastore.
-   *
-   * @param sessionID unique id of session to delete stored information from
-   */
-  public void deleteFromCustomDatabase(String sessionID) {
-    BooksMemoryUtils.deleteAllStoredBookInformation(sessionID, customDatastore);
   }
 
   /**


### PR DESCRIPTION
New commits start at: 2024ef0. Previous commits in PR #78.

Add testing for Book intents that require authorization, including: library, add, delete, friends, mylikes and friendlikes intents. To do so, mocked BookUtils.java (handles requests to Books API), PeopleUtils.java (handles requests to People API) and OAuthHelper.java (handles Oauth credential storage). Modified BookAgent and BookAgentHelper class to pass BookUtils, PeopleUtils, and OAuthHelper objects as parameters, allowing for mocks to be passed for testing purposes.

Create BooksTestHelper.java

Helper class to set up mocks to be passed to BooksAgent to handle intents that require authorization for testing
Creates BooksAgent instance and verifies the output, display, and redirect are correct for each intent
Create BookAgentAuthIntentsTest.java

Tests authorization intents, including library, add, delete, friends, mylikes, and friendlikes intent
Update BookAgentTest.java

Update tests for generic book intents that don't require authorization to match mock framework laid out in BooksTestHelper.java